### PR TITLE
Add default options to fix importing all locales

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const Replace = require('broccoli-string-replace');
 
 const optionsField = 'ember-power-calendar-date-fns';
 const defaultOptions = {
-  includeLocales: true,
+  includeLocales: ['en-US', 'fr', 'es', 'de', 'it'],
 };
 
 function localeVarName(locale) {


### PR DESCRIPTION
Exporting this module does code replacement in terms of which locales are imported from `date-fns`. By default all locales are imported which is not recommended by date-fns [documentation](https://date-fns.org/v2.29.3/docs/I18n). This interferes with Embroider since there is no default export in `date-fns/locales`.

Since the addon itself is not maintained at the moment we have forked it and introduced a minimal change to avoid breaking.

This PR aims to add languages that we use in Qonto as default values to avoid trying to import all locales and break the addon.

[Scaling task](https://www.notion.so/qonto/ui-kit-Cannot-read-properties-of-undefined-at-localeStartOfWeek-1b7d909f2171439c8fd1291eaf8e0737)